### PR TITLE
Arreglo error en Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3-alpine3.7
+FROM python:3-alpine3.15
 
-RUN apk add make bash gcc git musl-dev
+RUN apk add make bash gcc git musl-dev libffi-dev
 RUN pip install --upgrade pip
 RUN pip install yapf PyGithub
 


### PR DESCRIPTION
## Problema 
Tira un error al instalar PyGithub. 

## Solución
Se agrega `apk add libffi-dev`. Además, se actualiza la imagen 