### PR TITLE
add pip toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3-alpine3.15
 
 RUN apk add make bash gcc git musl-dev libffi-dev
 RUN pip install --upgrade pip
-RUN pip install yapf PyGithub
+RUN pip install yapf PyGithub toml
 
 COPY lib /lib
 RUN chmod -R 777 /lib


### PR DESCRIPTION
Toml package is needed for using pyproject.toml as a configuration file