### PR TITLE
Update entrypoint.sh

### DIFF
--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -3,6 +3,8 @@ set -e
 
 if ! git status > /dev/null 2>&1 ; then git init ; fi
 
+git config --global --add safe.directory /github/workspace
+
 REMOTE_TOKEN_URL="https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
 if ! git remote | grep "origin" > /dev/null 2>&1
 then


### PR DESCRIPTION
workaround for:
```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

https://github.com/actions/checkout/issues/760